### PR TITLE
feat: split out KW from K

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,7 @@ pub enum K {
          //Quote(Box<K>) // Is Quote a noun?
 }
 #[derive(Clone, Debug, PartialEq)]
-pub enum KW {
-    // KWords
+pub enum KW /* KWords */ {
     Noun(K),
     // Function{ body, args, curry, env }
     // View{ value, r, cache, depends->val }
@@ -131,10 +130,20 @@ pub fn eval(ast: Vec<KW>) -> Result<KW, &'static str> {
         [KW::Noun(_)] => Ok(ast[0].clone()),
         [KW::Verb { name: _ }, KW::Noun(_)] => todo!("monad"),
         [KW::Noun(_), KW::Verb { name }, KW::Noun(_)] => {
-            Ok(apply_primitive(name, Some(ast[0].clone()), ast[2].clone()).unwrap())
+            let r = apply_primitive(name, Some(ast[0].clone()), ast[2].clone()).unwrap();
+            let mut new_ast: Vec<KW> = vec![]; // TODO: shorten this, concat!() macro?
+            new_ast.extend(ast[..ast.len()-3].iter().cloned());
+            new_ast.append(&mut vec![r]);
+            eval(new_ast)
         }
         [_, _, _] => Err("syntax error"),
-        [_, ..] => eval(ast[ast.len() - 3..].to_vec()),
+        [_, ..] => {
+            let r = eval(ast[ast.len() - 3..].to_vec()).unwrap();
+            let mut new_ast: Vec<KW> = vec![]; // TODO: shorten this, concat!() macro?
+            new_ast.extend(ast[..ast.len()-3].iter().cloned());
+            new_ast.append(&mut vec![r]);
+            eval(new_ast)
+        },
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,29 +1,31 @@
 use polars::prelude::*;
 use rok::*;
 
+use rok::KW::*;
+
 #[test]
 fn test_1() {
-    assert_eq!(scan("1").unwrap(), vec![K::Bool(1u8)]);
-    assert_eq!(scan("2").unwrap(), vec![K::Int(Some(2))]);
-    assert_eq!(scan("3.14").unwrap(), vec![K::Float(3.14)]);
-    assert_eq!(scan("1 0 1 0 1").unwrap(), vec![K::BoolArray(Series::new("", [1, 0, 1, 0, 1u8]))]);
-    assert_eq!(scan("1 2 3").unwrap(), vec![K::IntArray(Series::new("", [1, 2, 3i64]))]);
-    assert_eq!(scan("1 2 3.14").unwrap(), vec![K::FloatArray(Series::new("", [1., 2., 3.14]))]);
+    assert_eq!(scan("1").unwrap(), vec![Noun(K::Bool(1u8))]);
+    assert_eq!(scan("2").unwrap(), vec![Noun(K::Int(Some(2)))]);
+    assert_eq!(scan("3.14").unwrap(), vec![Noun(K::Float(3.14))]);
+    assert_eq!(scan("1 0 1 0 1").unwrap(), vec![Noun(K::BoolArray(Series::new("", [1, 0, 1, 0, 1u8])))]);
+    assert_eq!(scan("1 2 3").unwrap(), vec![Noun(K::IntArray(Series::new("", [1, 2, 3i64])))]);
+    assert_eq!(scan("1 2 3.14").unwrap(), vec![Noun(K::FloatArray(Series::new("", [1., 2., 3.14])))]);
 }
 
 #[test]
 fn test_2() {
     assert_eq!(
         scan("2 + 2").unwrap(),
-        vec![K::Int(Some(2)), K::Verb { name: "+".to_string() }, K::Int(Some(2))]
+        vec![Noun(K::Int(Some(2))), Verb { name: "+".to_string() }, Noun(K::Int(Some(2)))]
     );
-    assert_eq!(eval(scan("2 + 2").unwrap()).unwrap(), K::Int(Some(4)));
+    assert_eq!(eval(scan("2 + 2").unwrap()).unwrap(), Noun(K::Int(Some(4))));
 
     assert_eq!(
         scan("1.0 + 2.0").unwrap(),
-        vec![K::Float(1.0), K::Verb { name: "+".to_string() }, K::Float(2.0)]
+        vec![Noun(K::Float(1.0)), Verb { name: "+".to_string() }, Noun(K::Float(2.0))]
     );
-    assert_eq!(eval(scan("1.0 + 2.0").unwrap()).unwrap(), K::Float(3.0));
+    assert_eq!(eval(scan("1.0 + 2.0").unwrap()).unwrap(), Noun(K::Float(3.0)));
 
-    assert_eq!(eval(scan("1 0 1 0 1 + 2").unwrap()).unwrap(), K::IntArray(Series::new("", [3, 2, 3, 2, 3])));
+    assert_eq!(eval(scan("1 0 1 0 1 + 2").unwrap()).unwrap(), Noun(K::IntArray(Series::new("", [3, 2, 3, 2, 3]))));
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -8,9 +8,15 @@ fn test_1() {
     assert_eq!(scan("1").unwrap(), vec![Noun(K::Bool(1u8))]);
     assert_eq!(scan("2").unwrap(), vec![Noun(K::Int(Some(2)))]);
     assert_eq!(scan("3.14").unwrap(), vec![Noun(K::Float(3.14))]);
-    assert_eq!(scan("1 0 1 0 1").unwrap(), vec![Noun(K::BoolArray(Series::new("", [1, 0, 1, 0, 1u8])))]);
+    assert_eq!(
+        scan("1 0 1 0 1").unwrap(),
+        vec![Noun(K::BoolArray(Series::new("", [1, 0, 1, 0, 1u8])))]
+    );
     assert_eq!(scan("1 2 3").unwrap(), vec![Noun(K::IntArray(Series::new("", [1, 2, 3i64])))]);
-    assert_eq!(scan("1 2 3.14").unwrap(), vec![Noun(K::FloatArray(Series::new("", [1., 2., 3.14])))]);
+    assert_eq!(
+        scan("1 2 3.14").unwrap(),
+        vec![Noun(K::FloatArray(Series::new("", [1., 2., 3.14])))]
+    );
 }
 
 #[test]
@@ -26,6 +32,14 @@ fn test_2() {
         vec![Noun(K::Float(1.0)), Verb { name: "+".to_string() }, Noun(K::Float(2.0))]
     );
     assert_eq!(eval(scan("1.0 + 2.0").unwrap()).unwrap(), Noun(K::Float(3.0)));
+    assert_eq!(eval(scan("1.0 - 2.0").unwrap()).unwrap(), Noun(K::Float(-1.0)));
+    assert_eq!(eval(scan("2.0 * 2.0").unwrap()).unwrap(), Noun(K::Float(4.0)));
+    assert_eq!(eval(scan("10 % 2").unwrap()).unwrap(), Noun(K::Int(Some(5))));
 
-    assert_eq!(eval(scan("1 0 1 0 1 + 2").unwrap()).unwrap(), Noun(K::IntArray(Series::new("", [3, 2, 3, 2, 3]))));
+    assert_eq!(
+        eval(scan("1 0 1 0 1 + 2").unwrap()).unwrap(),
+        Noun(K::IntArray(Series::new("", [3, 2, 3, 2, 3])))
+    );
+
+    // assert_eq!(eval(scan("1 2 3 + 4 5 6").unwrap()).unwrap(), Noun(K::IntArray(Series::new("", [5, 7, 9]))));
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -26,6 +26,7 @@ fn test_2() {
         vec![Noun(K::Int(Some(2))), Verb { name: "+".to_string() }, Noun(K::Int(Some(2)))]
     );
     assert_eq!(eval(scan("2 + 2").unwrap()).unwrap(), Noun(K::Int(Some(4))));
+    assert_eq!(eval(scan("2 + 2 + 2").unwrap()).unwrap(), Noun(K::Int(Some(6))));
 
     assert_eq!(
         scan("1.0 + 2.0").unwrap(),


### PR DESCRIPTION
Split out arrays into the `K` enum separate from the `KW` words enum.
That way we can `impl std::ops::Add` and the other maths ops for `K`.